### PR TITLE
支持vc2010编译

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,16 @@
       "cflags": [
         "-DLOGGER_LEVEL=LL_WARN"
       ],
+      'configurations': {
+        'Release': {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'ExceptionHandling': '1',
+              'PreprocessorDefinitions': ['LOGGER_LEVEL=LL_WARN'],
+            }
+          }
+        }
+      },
 	  "conditions": [
 	  	[ "OS == 'mac'", {
 		  "xcode_settings": {

--- a/src/CppJieba/Limonp/StdExtension.hpp
+++ b/src/CppJieba/Limonp/StdExtension.hpp
@@ -7,6 +7,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#elif defined _MSC_VER
+#include <unordered_map>
+#include <unordered_set>
+
 #else
 #include <tr1/unordered_map>
 #include <tr1/unordered_set>

--- a/src/CppJieba/Trie.hpp
+++ b/src/CppJieba/Trie.hpp
@@ -1,24 +1,6 @@
 #ifndef CPPJIEBA_TRIE_HPP
 #define CPPJIEBA_TRIE_HPP
 
-const class my_nullptr_t
-{
-    public:
-        /* Return 0 for any class pointer */
-        template<typename T> operator T*() const { return 0; }
-
-        /* Return 0 for any member pointer */
-        template<typename T, typename U> operator T U::*() const { return 0; }
-
-        /* Safe boolean conversion */
-        operator void*() const { return 0; }
-
-    private:
-        /* Not allowed to get the address */
-        void operator&() const;
-
-} my_nullptr = {};
-
 #include "Limonp/StdExtension.hpp"
 #include <vector>
 #include <queue>
@@ -135,7 +117,7 @@ namespace CppJieba
                     Unicode::value_type ch = *(begin + i);
                     res[i].uniCh = ch;
                     assert(res[i].dag.empty());
-                    res[i].dag.push_back(pair<vector<Unicode >::size_type, const DictUnit* >(i, my_nullptr));
+                    res[i].dag.push_back(pair<vector<Unicode >::size_type, const DictUnit* >(i, static_cast<const DictUnit*>(NULL)));
                     bool flag = false;
 
                     // rollback

--- a/src/CppJieba/Trie.hpp
+++ b/src/CppJieba/Trie.hpp
@@ -1,6 +1,24 @@
 #ifndef CPPJIEBA_TRIE_HPP
 #define CPPJIEBA_TRIE_HPP
 
+const class my_nullptr_t
+{
+    public:
+        /* Return 0 for any class pointer */
+        template<typename T> operator T*() const { return 0; }
+
+        /* Return 0 for any member pointer */
+        template<typename T, typename U> operator T U::*() const { return 0; }
+
+        /* Safe boolean conversion */
+        operator void*() const { return 0; }
+
+    private:
+        /* Not allowed to get the address */
+        void operator&() const;
+
+} my_nullptr = {};
+
 #include "Limonp/StdExtension.hpp"
 #include <vector>
 #include <queue>
@@ -117,7 +135,7 @@ namespace CppJieba
                     Unicode::value_type ch = *(begin + i);
                     res[i].uniCh = ch;
                     assert(res[i].dag.empty());
-                    res[i].dag.push_back(pair<vector<Unicode >::size_type, const DictUnit* >(i, NULL));
+                    res[i].dag.push_back(pair<vector<Unicode >::size_type, const DictUnit* >(i, my_nullptr));
                     bool flag = false;
 
                     // rollback


### PR DESCRIPTION
直接使用nullptr的话，gcc版本小于4.6.0则无法编译通过，因此定义了一个my_nullptr