### PR TITLE
Explicitly use `nodejieba.node` when requiring native module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var nodejieba = require("./build/Release/nodejieba");
+var nodejieba = require("./build/Release/nodejieba.node");
 nodejieba.DEFAULT_DICT = __dirname + "/dict/jieba.dict.utf8",
 nodejieba.DEFAULT_HMM_DICT = __dirname + "/dict/hmm_model.utf8",
 nodejieba.DEFAULT_USER_DICT = __dirname + "/dict/user.dict.utf8";


### PR DESCRIPTION
Some things that override node's `require` (e.g. jest) might break when
including nodejieba since. This is a workaround until they fix that.

有的库重写了 require，没能自动匹配 node 后缀的文件，比如 [facebook/jest](https://github.com/facebook/jest/)，希望 nodejieba 能够显示声明依赖的是 node 后缀的文件。