### PR TITLE
fix second element parse error in dict

### DIFF
--- a/deps/cppjieba/DictTrie.hpp
+++ b/deps/cppjieba/DictTrie.hpp
@@ -118,7 +118,7 @@ class DictTrie {
         } else {
           MakeNodeInfo(node_info, 
                 buf[0], 
-                (buf.size() == 2 ? atoi(buf[1].c_str()) : user_word_default_weight_),
+                (buf.size() == 2 ? user_word_default_weight_ : atoi(buf[1].c_str())),
                 (buf.size() == 3 ? buf[2] : buf[1]));
         }
         static_node_infos_.push_back(node_info);


### PR DESCRIPTION
Same as cppjieba, I think there is a bug when `buf.size()==2`. It is because that if `buf.size()==2`, the dict looks like `大神 n`. The second element is not a number. Line 121 should be `(buf.size() == 2 ? user_word_default_weight_:atoi(buf[1].c_str()))`, not `(buf.size() == 2 ? atoi(buf[1].c_str()) : user_word_default_weight_),`. Sorry for my negligence. I submit the code before reading the code. It is my bad.