### PR TITLE
对关键词抽取功能进行优化

### DIFF
--- a/deps/cppjieba/FullSegment.hpp
+++ b/deps/cppjieba/FullSegment.hpp
@@ -48,17 +48,17 @@ class FullSegment: public SegmentBase {
   void Cut(RuneStrArray::const_iterator begin, 
         RuneStrArray::const_iterator end, 
         vector<WordRange>& res) const {
-    //resut of searching in trie tree
+    // resut of searching in trie tree
     LocalVector<pair<size_t, const DictUnit*> > tRes;
 
-    //max index of res's words
-    int maxIdx = 0;
+    // max index of res's words
+    size_t maxIdx = 0;
 
     // always equals to (uItr - begin)
-    int uIdx = 0;
+    size_t uIdx = 0;
 
-    //tmp variables
-    int wordLen = 0;
+    // tmp variables
+    size_t wordLen = 0;
     assert(dictTrie_);
     vector<struct Dag> dags;
     dictTrie_->Find(begin, end, dags);

--- a/deps/cppjieba/Jieba.hpp
+++ b/deps/cppjieba/Jieba.hpp
@@ -2,22 +2,25 @@
 #define CPPJIEAB_JIEBA_H
 
 #include "QuerySegment.hpp"
-//#include "LevelSegment.hpp"
+#include "KeywordExtractor.hpp"
 
 namespace cppjieba {
 
 class Jieba {
  public:
-  Jieba(const string& dict_path, const string& model_path, const string& user_dict_path) 
+  Jieba(const string& dict_path, 
+        const string& model_path,
+        const string& user_dict_path, 
+        const string& idfPath, 
+        const string& stopWordPath) 
     : dict_trie_(dict_path, user_dict_path),
       model_(model_path),
       mp_seg_(&dict_trie_),
       hmm_seg_(&model_),
       mix_seg_(&dict_trie_, &model_),
       full_seg_(&dict_trie_),
-      query_seg_(&dict_trie_, &model_)
-      //level_seg_(&dict_trie_),
-      {
+      query_seg_(&dict_trie_, &model_),
+      extractor(&dict_trie_, &model_, idfPath, stopWordPath) {
   }
   ~Jieba() {
   }
@@ -69,6 +72,15 @@ class Jieba {
     return dict_trie_.InsertUserWord(word, tag);
   }
 
+  bool InsertUserWord(const string& word,int freq, const string& tag = UNKNOWN_TAG) {
+    return dict_trie_.InsertUserWord(word,freq, tag);
+  }
+
+  bool Find(const string& word)
+  {
+    return dict_trie_.Find(word);
+  }
+
   void ResetSeparators(const string& s) {
     //TODO
     mp_seg_.ResetSeparators(s);
@@ -81,10 +93,23 @@ class Jieba {
   const DictTrie* GetDictTrie() const {
     return &dict_trie_;
   } 
+  
   const HMMModel* GetHMMModel() const {
     return &model_;
   }
- 
+
+  void LoadUserDict(const vector<string>& buf)  {
+    dict_trie_.LoadUserDict(buf);
+  }
+
+  void LoadUserDict(const set<string>& buf)  {
+    dict_trie_.LoadUserDict(buf);
+  }
+
+  void LoadUserDict(const string& path)  {
+    dict_trie_.LoadUserDict(path);
+  }
+
  private:
   DictTrie dict_trie_;
   HMMModel model_;
@@ -95,8 +120,9 @@ class Jieba {
   MixSegment mix_seg_;
   FullSegment full_seg_;
   QuerySegment query_seg_;
-  //LevelSegment level_seg_;
 
+ public:
+  KeywordExtractor extractor;
 }; // class Jieba
 
 } // namespace cppjieba

--- a/deps/cppjieba/KeywordExtractor.hpp
+++ b/deps/cppjieba/KeywordExtractor.hpp
@@ -3,10 +3,15 @@
 
 #include <cmath>
 #include <set>
-#include "Jieba.hpp"
+#include "MixSegment.hpp"
+#include "Utils.hpp"
 
 namespace cppjieba {
+
 using namespace limonp;
+using namespace std;
+
+const static string TFIDF_DEFAULT_ALLOWED_POS = "";
 
 /*utf8*/
 class KeywordExtractor {
@@ -34,51 +39,79 @@ class KeywordExtractor {
     LoadIdfDict(idfPath);
     LoadStopWordDict(stopWordPath);
   }
-  KeywordExtractor(const Jieba& jieba, 
-        const string& idfPath, 
-        const string& stopWordPath) 
-    : segment_(jieba.GetDictTrie(), jieba.GetHMMModel()) {
-    LoadIdfDict(idfPath);
-    LoadStopWordDict(stopWordPath);
-  }
   ~KeywordExtractor() {
   }
 
-  void Extract(const string& sentence, vector<string>& keywords, size_t topN) const {
+  void Extract(const string& sentence, vector<string>& keywords, size_t topN,
+    const string& allowedPOS=TFIDF_DEFAULT_ALLOWED_POS) const {
+    vector<pair<string, string>> words;
+    segment_.Tag(sentence, words);
     vector<Word> topWords;
-    Extract(sentence, topWords, topN);
+    Extract(words, topWords, topN, allowedPOS);
     for (size_t i = 0; i < topWords.size(); i++) {
       keywords.push_back(topWords[i].word);
     }
   }
 
-  void Extract(const string& sentence, vector<pair<string, double> >& keywords, size_t topN) const {
+  void Extract(const string& sentence, vector<pair<string, double> >& keywords, size_t topN,
+    const string& allowedPOS=TFIDF_DEFAULT_ALLOWED_POS) const {
+    vector<pair<string, string>> words;
+    segment_.Tag(sentence, words);
     vector<Word> topWords;
-    Extract(sentence, topWords, topN);
+    Extract(words, topWords, topN, allowedPOS);
     for (size_t i = 0; i < topWords.size(); i++) {
       keywords.push_back(pair<string, double>(topWords[i].word, topWords[i].weight));
     }
   }
 
-  void Extract(const string& sentence, vector<Word>& keywords, size_t topN) const {
-    vector<string> words;
-    segment_.Cut(sentence, words);
+  void Extract(const vector<pair<string, string> >& words, vector<pair<string, double> >& keywords, size_t topN,
+    const string& allowedPOS=TFIDF_DEFAULT_ALLOWED_POS) const {
+    vector<Word> topWords;
+    Extract(words, topWords, topN, allowedPOS);
+    for (size_t i = 0; i < topWords.size(); i++) {
+      keywords.push_back(pair<string, double>(topWords[i].word, topWords[i].weight));
+    }
+  }
+
+  void ExtractWithWordsStr(const string& wordsStr, vector<pair<string, double> >& keywords, size_t topN,
+    const string& allowedPOS=TFIDF_DEFAULT_ALLOWED_POS) const {
+    vector<pair<string, string>> words = Utils::ConvertWordsStr2Vector(wordsStr);
+    vector<Word> topWords;
+    Extract(words, topWords, topN, allowedPOS);
+    for (size_t i = 0; i < topWords.size(); i++) {
+      keywords.push_back(pair<string, double>(topWords[i].word, topWords[i].weight));
+    }
+  }
+
+  void Extract(const vector<pair<string, string> >& words, vector<Word>& keywords, size_t topN,
+    const string& allowedPOS=TFIDF_DEFAULT_ALLOWED_POS) const {
+//    vector<string> words;
+//    segment_.Cut(sentence, words);
+//    vector<pair<string, string>> words;
+//    segment_.Tag(sentence, words);
 
     map<string, Word> wordmap;
     size_t offset = 0;
+    string tempPOS = allowedPOS;
+    if ("" == tempPOS) {
+      tempPOS = TFIDF_DEFAULT_ALLOWED_POS;
+    }
+    set<string> allowedPOSSet = Utils::GetAllowedPOS(tempPOS);
+
     for (size_t i = 0; i < words.size(); ++i) {
       size_t t = offset;
-      offset += words[i].size();
-      if (IsSingleWord(words[i]) || stopWords_.find(words[i]) != stopWords_.end()) {
+      offset += words[i].first.size();
+      if ("" == words[i].first || IsSingleWord(words[i].first) || stopWords_.find(words[i].first) != stopWords_.end()
+            || !Utils::IsAllowedPOS(allowedPOSSet, words[i].second)) {
         continue;
       }
-      wordmap[words[i]].offsets.push_back(t);
-      wordmap[words[i]].weight += 1.0;
+      wordmap[words[i].first].offsets.push_back(t);
+      wordmap[words[i].first].weight += 1.0;
     }
-    if (offset != sentence.size()) {
-      XLOG(ERROR) << "words illegal";
-      return;
-    }
+//    if (offset != sentence.size()) {
+//      XLOG(ERROR) << "words illegal";
+//      return;
+//    }
 
     keywords.clear();
     keywords.reserve(wordmap.size());

--- a/deps/cppjieba/TextRankExtractor.hpp
+++ b/deps/cppjieba/TextRankExtractor.hpp
@@ -1,19 +1,23 @@
 #ifndef CPPJIEBA_TEXTRANK_EXTRACTOR_H
 #define CPPJIEBA_TEXTRANK_EXTRACTOR_H
 
+#include <iostream>
+#include <set>
 #include <cmath>
 #include "Jieba.hpp"
+#include "Utils.hpp"
 
 namespace cppjieba {
   using namespace limonp;
   using namespace std;
+  const static string TEXTRANK_DEFAULT_ALLOWED_POS = "ns,n,vn,v";
 
   class TextRankExtractor {
   public:
     typedef struct _Word {string word;vector<size_t> offsets;double weight;}    Word; // struct Word
   private:
     typedef std::map<string,Word> WordMap;
-  
+
     class WordGraph{
     private:
       typedef double Score;
@@ -105,52 +109,87 @@ namespace cppjieba {
     ~TextRankExtractor() {
     }
 
-    void Extract(const string& sentence, vector<string>& keywords, size_t topN) const {
+    void Extract(const string& sentence, vector<string>& keywords, size_t topN,
+        const string& allowedPOS=TEXTRANK_DEFAULT_ALLOWED_POS) const {
+      vector<pair<string, string>> words;
+      segment_.Tag(sentence, words);
       vector<Word> topWords;
-      Extract(sentence, topWords, topN);
+      Extract(words, topWords, topN, allowedPOS);
       for (size_t i = 0; i < topWords.size(); i++) {
         keywords.push_back(topWords[i].word);
       }
     }
 
-    void Extract(const string& sentence, vector<pair<string, double> >& keywords, size_t topN) const {
+    void Extract(const string& sentence, vector<pair<string, double> >& keywords, size_t topN,
+        const string& allowedPOS=TEXTRANK_DEFAULT_ALLOWED_POS) const {
+      vector<pair<string, string>> words;
+      segment_.Tag(sentence, words);
       vector<Word> topWords;
-      Extract(sentence, topWords, topN);
+      Extract(words, topWords, topN, allowedPOS);
       for (size_t i = 0; i < topWords.size(); i++) {
         keywords.push_back(pair<string, double>(topWords[i].word, topWords[i].weight));
       }
     }
 
-    void Extract(const string& sentence, vector<Word>& keywords, size_t topN, size_t span=5,size_t rankTime=10) const {
-      vector<string> words;
-      segment_.Cut(sentence, words);
+    void Extract(const vector<pair<string, string> >& words, vector<pair<string, double> >& keywords, size_t topN,
+        const string& allowedPOS=TEXTRANK_DEFAULT_ALLOWED_POS) const {
+      vector<Word> topWords;
+      Extract(words, topWords, topN, allowedPOS);
+      for (size_t i = 0; i < topWords.size(); i++) {
+        keywords.push_back(pair<string, double>(topWords[i].word, topWords[i].weight));
+      }
+    }
+
+    void ExtractWithWordsStr(const string& wordsStr, vector<pair<string, double> >& keywords, size_t topN,
+        const string& allowedPOS=TEXTRANK_DEFAULT_ALLOWED_POS) const {
+      vector<pair<string, string>> words = Utils::ConvertWordsStr2Vector(wordsStr);
+      vector<Word> topWords;
+      Extract(words, topWords, topN, allowedPOS);
+      for (size_t i = 0; i < topWords.size(); i++) {
+        keywords.push_back(pair<string, double>(topWords[i].word, topWords[i].weight));
+      }
+    }
+
+    void Extract(const vector<pair<string, string> >& words, vector<Word>& keywords, size_t topN,
+        const string& allowedPOS=TEXTRANK_DEFAULT_ALLOWED_POS, size_t span=5, size_t rankTime=10) const {
+//      vector<string> words;
+//      segment_.Cut(sentence, words);
+//      vector<pair<string, string>> words;
+//      segment_.Tag(sentence, words);
 
       TextRankExtractor::WordGraph graph;
       WordMap wordmap;
       size_t offset = 0;
+      string tempPOS = allowedPOS;
+      if ("" == tempPOS) {
+        tempPOS = TEXTRANK_DEFAULT_ALLOWED_POS;
+      }
+      set<string> allowedPOSSet = Utils::GetAllowedPOS(tempPOS);
 
       for(size_t i=0; i < words.size(); i++){
         size_t t = offset;
-        offset += words[i].size();
-        if (IsSingleWord(words[i]) || stopWords_.find(words[i]) != stopWords_.end()) {
+        offset += words[i].first.size();
+        if ("" == words[i].first || IsSingleWord(words[i].first) || stopWords_.find(words[i].first) != stopWords_.end()
+            || !Utils::IsAllowedPOS(allowedPOSSet, words[i].second)) {
           continue;
         }
-        for(size_t j=i+1,skip=0;j<i+span+skip && j<words.size();j++){
-          if (IsSingleWord(words[j]) || stopWords_.find(words[j]) != stopWords_.end()) {
-            skip++;
+//        for(size_t j=i+1,skip=0;j<i+span+skip && j<words.size();j++){
+        for(size_t j=i+1; j<i+span && j<words.size(); j++){  // 去除skip
+          if ("" == words[i].first || IsSingleWord(words[j].first) || stopWords_.find(words[j].first) != stopWords_.end()
+                || !Utils::IsAllowedPOS(allowedPOSSet, words[j].second)) {
+//            skip++;
             continue;
           }
-          graph.addEdge(words[i],words[j],1);
+          graph.addEdge(words[i].first,words[j].first,1);
         }
-        wordmap[words[i]].offsets.push_back(t);
+        wordmap[words[i].first].offsets.push_back(t);
       }
-      if (offset != sentence.size()) {
-        XLOG(ERROR) << "words illegal";
-        return;
-      }
-
+//      if (offset != sentence.size()) {
+//        XLOG(ERROR) << "words illegal";
+//        return;
+//      }
       graph.rank(wordmap,rankTime);
-      
+
       keywords.clear();
       keywords.reserve(wordmap.size());
       for (WordMap::iterator itr = wordmap.begin(); itr != wordmap.end(); ++itr) {

--- a/deps/cppjieba/Utils.hpp
+++ b/deps/cppjieba/Utils.hpp
@@ -1,0 +1,69 @@
+#ifndef CPPJIEBA_UTILS_H
+#define CPPJIEBA_UTILS_H
+
+#include <set>
+#include "limonp/StringUtil.hpp"
+
+namespace cppjieba {
+
+  using namespace std;
+  class Utils {
+    public:
+        /**
+           将allowedPOS字符串，转换成set，例如：allowedPOS="vn,n,v,ns"
+        */
+        static set<string> GetAllowedPOS(const string& allowedPOS, const string delim=",") {
+            set<string> result;
+            if("" == allowedPOS) {
+                return  result;
+            }
+
+            string strs = allowedPOS + delim;
+            size_t pos;
+            size_t size = strs.size();
+
+            for (size_t i = 0; i < size; ++i) {
+                pos = strs.find(delim, i);
+                if( pos < size) {
+                    string s = strs.substr(i, pos - i);
+                    result.insert(s);
+                    i = pos + delim.size() - 1;
+                }
+            }
+            return result;
+        }
+
+        /**
+            判断词性是否属于允许的词性中
+        */
+        static bool IsAllowedPOS(set<string>& allowedPOSSet, const string& wordTag) {
+            bool result = true;
+            if (allowedPOSSet.size() > 0 && allowedPOSSet.count(wordTag) == 0) {
+                result = false;
+            }
+            return result;
+        }
+
+        /**
+            把words字符串转成vector
+            wordsStr = '词1/n 词2/v'
+        */
+        static vector<pair<string, string>> ConvertWordsStr2Vector(const string& wordsStr) {
+            vector<pair<string, string>> result;
+            vector<string> items = limonp::Split(wordsStr, " ");
+            for (size_t i = 0; i < items.size(); i++) {
+                vector<string> wordTag = limonp::Split(items[i], "/");
+                if (wordTag.size() == 2 && wordTag[0].length() > 0 && wordTag[1].length() > 0) {
+                    result.push_back(pair<string, string>(wordTag[0], wordTag[1]));
+                }
+            }
+            return result;
+        }
+
+  };
+
+}
+
+
+#endif // CPPJIEBA_UTILS_H
+

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var nodejieba = require( __dirname + "/build/Release/nodejieba.node");
-nodejieba.DEFAULT_DICT = __dirname + "/dict/jieba.dict.utf8",
-nodejieba.DEFAULT_HMM_DICT = __dirname + "/dict/hmm_model.utf8",
+nodejieba.DEFAULT_DICT = __dirname + "/dict/jieba.dict.utf8";
+nodejieba.DEFAULT_HMM_DICT = __dirname + "/dict/hmm_model.utf8";
 nodejieba.DEFAULT_USER_DICT = __dirname + "/dict/user.dict.utf8";
 nodejieba.DEFAULT_IDF_DICT = __dirname + "/dict/idf.utf8";
 nodejieba.DEFAULT_STOP_WORD_DICT = __dirname + "/dict/stop_words.utf8";
@@ -20,7 +20,7 @@ nodejieba.load = function (dictJson) {
 
   isDictLoaded = true;
   return someFunct.call(this, dict, hmmDict, userDict, idfDict, stopWordDict);
-}
+};
 
 function wrapWithDictLoad(obj, functName) {
   var someFunct = obj[functName];
@@ -39,7 +39,18 @@ wrapWithDictLoad(nodejieba, "cutForSearch");
 wrapWithDictLoad(nodejieba, "cutSmall");
 wrapWithDictLoad(nodejieba, "tag");
 wrapWithDictLoad(nodejieba, "extract");
+wrapWithDictLoad(nodejieba, "extractWithWords");
+wrapWithDictLoad(nodejieba, "textRankExtract");
+wrapWithDictLoad(nodejieba, "textRankExtractWithWords");
 wrapWithDictLoad(nodejieba, "insertWord");
+
+nodejieba.tagWordsToStr = function(words) {
+    var result = '';
+    for (var i = 0; i < words.length; i++) {
+        result += words[i].word + '/' + words[i].tag + ' ';
+    }
+    return result.trim();
+};
 
 module.exports = nodejieba;
 

--- a/lib/index.cpp
+++ b/lib/index.cpp
@@ -17,8 +17,14 @@ void init(Handle<Object> exports) {
         Nan::New<FunctionTemplate>(tag)->GetFunction());
   exports->Set(Nan::New<v8::String>("extract").ToLocalChecked(),
         Nan::New<FunctionTemplate>(extract)->GetFunction());
+  exports->Set(Nan::New<v8::String>("extractWithWords").ToLocalChecked(),
+        Nan::New<FunctionTemplate>(extractWithWords)->GetFunction());
   exports->Set(Nan::New<v8::String>("insertWord").ToLocalChecked(),
         Nan::New<FunctionTemplate>(insertWord)->GetFunction());
+  exports->Set(Nan::New<v8::String>("textRankExtract").ToLocalChecked(),
+        Nan::New<FunctionTemplate>(textRankExtract)->GetFunction());
+  exports->Set(Nan::New<v8::String>("textRankExtractWithWords").ToLocalChecked(),
+        Nan::New<FunctionTemplate>(textRankExtractWithWords)->GetFunction());
 }
 
 NODE_MODULE(nodejieba, init)

--- a/lib/nodejieba.h
+++ b/lib/nodejieba.h
@@ -11,6 +11,9 @@ extern NAN_METHOD(cutForSearch);
 extern NAN_METHOD(cutSmall);
 extern NAN_METHOD(tag);
 extern NAN_METHOD(extract);
+extern NAN_METHOD(extractWithWords);
+extern NAN_METHOD(textRankExtract);
+extern NAN_METHOD(textRankExtractWithWords);
 extern NAN_METHOD(insertWord);
 
 #endif // NODEJIBEA_SRC_NODEJIEBA_H

--- a/test/demo.js
+++ b/test/demo.js
@@ -24,7 +24,13 @@ console.log(result);
 
 result = nodejieba.tag(sentence);
 console.log(result);
+console.log('=======');
+console.log(nodejieba.extractWithWords(nodejieba.tagWordsToStr(result), 5));
+console.log(nodejieba.extract(sentence, 5));
 
+console.log(nodejieba.textRankExtractWithWords(nodejieba.tagWordsToStr(result), 5));
+console.log(nodejieba.textRankExtract(sentence, 5));
+console.log('=======');
 var topN = 5;
 result = nodejieba.extract(sentence, topN);
 console.log(result);
@@ -37,3 +43,6 @@ console.log(result);
 
 result = nodejieba.cutSmall("南京市长江大桥", 3);
 console.log(result);
+
+
+

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,10 @@ declare module "nodejieba" {
   export function cutAll(sentence: string): any;
   export function cutForSearch(sentence: string): any;
   export function tag(sentence: string): any;
-  export function extract(sentence: string, threshold: number): any;
+  export function extract(sentence: string, threshold: number, allowedPOS?:string): any;
   export function insertWord(sentence: string): any;
   export function cutSmall(sentence: string, small: number): any;
+    export function textRankExtract(sentence: string, threshold:number, allowedPOS?:string): any;
+    export function extractWithWords(wordsStr:string, threshold:number, allowedPOS?:string): any;
+    export function textRankExtractWithWords(wordsStr:string, threshold:number, allowedPOS?:string): any;
 }


### PR DESCRIPTION
1. 合并cppjieba最新代码https://github.com/yanyiwu/cppjieba
2. 添加nodejs调用textrank接口，并可以指定allowedPOS，优化textrank计算逻辑
3. 对于tfidf关键词抽取接口extract，优化可以指定allowedPOS
4. 对于textrank和tfidf接口，增加传入分词结果，直接获取结果的接口，避免重复分词