### PR TITLE
添加 binary 分发功能  

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
-var nodejieba = require( __dirname + "/build/Release/nodejieba.node");
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
+var nodejieba = require(binding_path);
+
 nodejieba.DEFAULT_DICT = __dirname + "/dict/jieba.dict.utf8";
 nodejieba.DEFAULT_HMM_DICT = __dirname + "/dict/hmm_model.utf8";
 nodejieba.DEFAULT_USER_DICT = __dirname + "/dict/user.dict.utf8";

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "结巴分词"
   ],
   "dependencies": {
-    "nan": "^2.14.0"
+    "nan": "^2.14.0",
+    "node-pre-gyp": "^0.14.0",
+    "node-pre-gyp-github": "^1.4.3"
   },
   "devDependencies": {
     "coveralls": "~2.11.6",
@@ -35,7 +37,15 @@
     "typescript": "^3.0.1"
   },
   "scripts": {
-    "test": "node test/demo.js && node test/load_dict_demo.js && mocha --timeout 10s -R spec test/test.js && mocha --timeout 10s -R spec test/load_dict_test.js"
+    "test": "node test/demo.js && node test/load_dict_demo.js && mocha --timeout 10s -R spec test/test.js && mocha --timeout 10s -R spec test/load_dict_test.js",
+    "install": "node-pre-gyp install --fallback-to-build"
+  },
+  "binary": {
+    "module_name": "nodejieba",
+    "module_path": "./build/Release/",
+    "host":  "https://github.com/yanyiwu/nodejieba/releases/download/",
+    "remote_path": "{version}",
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
   ],
   "dependencies": {
     "nan": "^2.14.0",
-    "node-pre-gyp": "^0.14.0",
-    "node-pre-gyp-github": "^1.4.3"
+    "node-pre-gyp": "^0.14.0"
   },
   "devDependencies": {
     "coveralls": "~2.11.6",
     "istanbul": "~0.4.1",
     "mocha": "~2.4.5",
     "should": "~8.3.1",
-    "typescript": "^3.0.1"
+    "typescript": "^3.0.1",
+    "node-pre-gyp-github": "^1.4.3"
   },
   "scripts": {
     "test": "node test/demo.js && node test/load_dict_demo.js && mocha --timeout 10s -R spec test/test.js && mocha --timeout 10s -R spec test/load_dict_test.js",


### PR DESCRIPTION
您好，由于某些原因，我希望这个项目可以使用 binary 分发包，这样在某些环境可以省去下载后编译的问题。需要合并一些代码，这些改动只保证了可以使用 node-pre-gyp，但是不同平台的二进制包还需要您根据 node-pre-gyp-github 的说明，手动上传

#### 引入依赖 
* [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) 
* [node-pre-gyp-github](https://github.com/bchr02/node-pre-gyp-github)

#### 注意事项
* 参考 [node-pre-gyp-github](https://github.com/bchr02/node-pre-gyp-github)
* node-pre-gyp-github 将文件直接存储至您的GitHub 对应的 release 资源下，