### PR TITLE
chore(travis-ci): 使用travis-ci构建并发布预编译包

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,133 @@
-os:
-  - linux
 language: node_js
-env:
-  - CXX=g++-4.8
-node_js:
-  - "iojs-3"
-  - "4.0.0"
-  - "5.7.0"
-  - "6.0.0"
-  - "6.9.1"
-  - "7.1.0"
-  - "10.0.0"
-  - "12.0.0"
-  - "13"
+
+stages:
+  - test
+  - name: deploy
+    if: tag IS present
+
+jobs:
+  include:
+
+    - &test
+      stage: test
+      os: linux
+      node_js: "iojs-3"
+      env:
+        - CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+      after_script: NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+    - <<: *test
+      node_js: "4.0.0"
+    - <<: *test
+      node_js: "5.7.0"
+    - <<: *test
+      node_js: "6.0.0"
+    - <<: *test
+      node_js: "6.9.1"
+    - <<: *test
+      node_js: "7.1.0"
+    - <<: *test
+      node_js: "10.0.0"
+    - <<: *test
+      node_js: "12.0.0"
+    - <<: *test
+      node_js: "13"
+
+    ## deploy linux
+    - &deploy
+      stage: deploy
+      os: linux
+      node_js: "6"
+      env:
+        - CXX=g++
+      script:
+        - ./node_modules/.bin/node-pre-gyp package
+      deploy:
+        provider: releases
+        token: ${GH_TOKEN}
+        file_glob: true
+        file:
+          - build/stage/*/**
+        skip_cleanup: true
+        on:
+          branch: master
+          tags: true
+    - <<: *deploy
+      node_js: "7"
+    - <<: *deploy
+      node_js: "8"
+    - <<: *deploy
+      node_js: "9"
+    - <<: *deploy
+      node_js: "10"
+    - <<: *deploy
+      node_js: "11"
+    - <<: *deploy
+      node_js: "12"
+    - <<: *deploy
+      node_js: "13"
+
+    ## deploy osx
+    - <<: *deploy
+      os: osx
+      node_js: "6"
+    - <<: *deploy
+      os: osx
+      node_js: "7"
+    - <<: *deploy
+      os: osx
+      node_js: "8"
+    - <<: *deploy
+      os: osx
+      node_js: "9"
+    - <<: *deploy
+      os: osx
+      node_js: "10"
+    - <<: *deploy
+      os: osx
+      node_js: "11"
+    - <<: *deploy
+      os: osx
+      node_js: "12"
+    - <<: *deploy
+      os: osx
+      node_js: "13"
+
+    ## deploy windows
+#    - <<: *deploy
+#      os: windows
+#      node_js: "6"
+#    - <<: *deploy
+#      os: windows
+#      node_js: "7"
+    - <<: *deploy
+      os: windows
+      node_js: "8"
+    - <<: *deploy
+      os: windows
+      node_js: "9"
+    - <<: *deploy
+      os: windows
+      node_js: "10"
+    - <<: *deploy
+      os: windows
+      node_js: "11"
+    - <<: *deploy
+      os: windows
+      node_js: "12"
+    - <<: *deploy
+      os: windows
+      node_js: "13"
+
+
 notifications:
   recipients:
     - i@yanyiwu.com
   email:
     on_success: change
     on_failure: always
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-after_script: NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
-deploy:
-  provider: releases
-  api_key: ${GH_TOKEN}
-  file_glob: true
-  file:
-    - releases/*
-  skip_cleanup: true
-  on:
-    branch: master
-    tags: true

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "module_name": "nodejieba",
     "module_path": "./build/Release/",
     "host":  "https://github.com/yanyiwu/nodejieba/releases/download/",
-    "remote_path": "{version}",
+    "remote_path": "v{version}",
     "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz"
   },
   "license": "MIT"


### PR DESCRIPTION
结果：https://github.com/sunzongzheng/nodejieba/releases

日志：https://travis-ci.org/github/sunzongzheng/nodejieba/builds/666179406?utm_medium=notification&utm_source=github_status

测试情况：macos node12、windows node8拉取release版本可用

已知缺陷：windows上node@6([编译日志](https://travis-ci.org/github/sunzongzheng/nodejieba/jobs/665796968?utm_medium=notification&utm_source=github_status))、node@7([编译日志](https://travis-ci.org/github/sunzongzheng/nodejieba/jobs/665796969?utm_medium=notification&utm_source=github_status))使用node-gyp编译不过，已放弃