### PR TITLE
增加当前正在使用的词典属性

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ nodejieba.load = function (dictJson) {
   stopWordDict = dictJson.stopWordDict || nodejieba.DEFAULT_STOP_WORD_DICT;
 
   isDictLoaded = true;
+
+  nodejieba.CURRENT_USER_DICT = userDict;
   return someFunct.call(this, dict, hmmDict, userDict, idfDict, stopWordDict);
 }
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ nodejieba.load = function (dictJson) {
 
   isDictLoaded = true;
 
+  nodejieba.CURRENT_DICT = dict;
+  nodejieba.CURRENT_HMM_DICT = hmmDict;
   nodejieba.CURRENT_USER_DICT = userDict;
+  nodejieba.CURRENT_IDF_DICT = idfDict;
+  nodejieba.CURRENT_STOP_WORD_DICT = stopWordDict;
   return someFunct.call(this, dict, hmmDict, userDict, idfDict, stopWordDict);
 }
 


### PR DESCRIPTION
为什么要这么做？

使用过程中，可能会加载多个不同的词典，为了防止重复加载词典，调用代码希望能获取当前词典地址，如果词典地址与要加载的相同，调用层就不用重复加载词典了