### PR TITLE
Make it worker_thread compatible

### DIFF
--- a/lib/index.cpp
+++ b/lib/index.cpp
@@ -21,4 +21,4 @@ void init(Local<Object> exports) {
         Nan::GetFunction(Nan::New<FunctionTemplate>(insertWord)).ToLocalChecked());
 }
 
-NODE_MODULE(nodejieba, init)
+NAN_MODULE_WORKER_ENABLED(nodejieba, init)


### PR DESCRIPTION
In my project, I'm using worker_thread (by workerpool) to asynchronize and speed up heavy works to avoid main thread blocking.

But nodejieba is not compatible to be used with worker_thread. According to https://github.com/josdejong/workerpool/issues/165, https://github.com/Automattic/node-canvas/issues/1394 and https://github.com/nodejs/nan/issues/844#issuecomment-477281991, it seems that we can simply change `NODE_MODULE` into `NAN_MODULE_WORKER_ENALBED` macro  to make it compatible.

Tests: 
- `npm test` all test is passing
-  worker_thread compatible tested with workerpool (sorry, I don't know how to write multi-thread tests using should, I've post test code below)


----


```js
// thread_test/lib.worker.js
const jieba = require("../index");
const workerpool = require("workerpool");

console.log("worker initialized");

function jiebaCutHMM(text) {
  return jieba.cutHMM(text);
}

workerpool.worker({
  jiebaCutHMM,
});

```

```js
// thread_test/lib.js
const workerpool = require("workerpool");
const pool = workerpool.pool(require.resolve("./lib.worker.js"), {
  workerType: "thread",
});

function exit() {
  pool.terminate();
}

async function jiebaCutHMM(text) {
  return await pool.exec("jiebaCutHMM", [text]);
}

exports.exit = exit;
exports.jiebaCutHMM = jiebaCutHMM;
```

```js
// thread_test/test.js
const lib = require('./lib');

Promise.all(
  Array.from({ length: 20 }, (v, k) => {
    const t = `上海大厦#${k + 1}`;
    const p = lib.jiebaCutHMM(t);
    console.log('jiebaCutHMM is called asynchronously, main thread is not blocking!');
    return p;
  })
)
  .then(console.log, console.log)
  .finally(() => {
    lib.exit();
  });
```

```
// output
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
jiebaCutHMM is called asynchronously, main thread is not blocking!
script end.
worker initialized
worker initialized
worker initialized
worker initialized
worker initialized
worker initialized
worker initialized
[
  [ '上海大厦', '#', '1' ],  [ '上海大厦', '#', '2' ],
  [ '上海大厦', '#', '3' ],  [ '上海大厦', '#', '4' ],
  [ '上海大厦', '#', '5' ],  [ '上海大厦', '#', '6' ],
  [ '上海大厦', '#', '7' ],  [ '上海大厦', '#', '8' ],
  [ '上海大厦', '#', '9' ],  [ '上海大厦', '#', '10' ],
  [ '上海大厦', '#', '11' ], [ '上海大厦', '#', '12' ],
  [ '上海大厦', '#', '13' ], [ '上海大厦', '#', '14' ],
  [ '上海大厦', '#', '15' ], [ '上海大厦', '#', '16' ],
  [ '上海大厦', '#', '17' ], [ '上海大厦', '#', '18' ],
  [ '上海大厦', '#', '19' ], [ '上海大厦', '#', '20' ]
]