### PR TITLE
upgrade node-pre-gyp to fix install problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ t.*
 *.pid
 node_modules
 npm-debug.log
+.idea

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var binary = require('node-pre-gyp');
+var binary = require('@mapbox/node-pre-gyp');
 var path = require('path');
 var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
 var nodejieba = require(binding_path);

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "结巴分词"
   ],
   "dependencies": {
-    "node-addon-api": "^3.0.2",
-    "node-pre-gyp": "^0.14.0"
+    "@mapbox/node-pre-gyp": "^1.0.4",
+    "node-addon-api": "^3.0.2"
   },
   "devDependencies": {
     "coveralls": "~2.11.6",


### PR DESCRIPTION
node-pre-gyp has been deprecated and only the scoped name `@mapbox/node-pre-gyp` will receive upgrades (as https://github.com/mapbox/node-pre-gyp#special-note-on-previous-package)

this change fix install problems caused by node-pre-gyp issues with node versions 12.x 14.x and higher 

fix: #116 #165 #162 and so.........on

```
error /project/node_modules/nodejieba: Command failed.
Exit code: 6
Command: node-pre-gyp install --fallback-to-build
Arguments: 
Directory: /project/node_modules/nodejieba
Output:
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.14.0
node-pre-gyp info using node@12.21.0 | darwin | x64
node-pre-gyp WARN Using needle for node-pre-gyp https download 
node-pre-gyp info check checked for "/project/node_modules/nodejieba/build/Release/nodejieba.node" (not found)
node-pre-gyp http GET https://github.com/yanyiwu/nodejieba/releases/download/v2.5.1/nodejieba-v2.5.1-node-v72-darwin-x64.tar.gz
node-pre-gyp http 301 https://github.com/yanyiwu/nodejieba/releases/download/v2.5.1/nodejieba-v2.5.1-node-v72-darwin-x64.tar.gz
node-pre-gyp ERR! Completion callback never invoked! 
node-pre-gyp ERR! System Darwin 19.6.0
node-pre-gyp ERR! command "/usr/local/Cellar/node/16.0.0/bin/node" "/project/node_modules/nodejieba/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /project/node_modules/nodejieba
node-pre-gyp ERR! node -v v12.21.0
node-pre-gyp ERR! node-pre-gyp -v v0.14.0
node-pre-gyp ERR! This is a bug in `node-pre-gyp`.
node-pre-gyp ERR! Try to update node-pre-gyp and file an issue if it does not help:
node-pre-gyp ERR!     <https://github.com/mapbox/node-pre-gyp/issues>
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.

```