### PR TITLE
Update node-pre-gyp to 1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "结巴分词"
   ],
   "dependencies": {
-    "@mapbox/node-pre-gyp": "^1.0.4",
+    "@mapbox/node-pre-gyp": "^1.0.9",
     "node-addon-api": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
```
nodejieba@2.6.0 requires tar@6.1.0 via @mapbox/node-pre-gyp@1.0.5
```

CVE-2021-37713