### PR TITLE
chore: fix publish secret and use correct runner os

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,22 @@ on:
 
 jobs:
   build:
-    name: Build binary for ${{ matrix.os }} and Node.js ${{ matrix.node-version }}
+    name: ${{ matrix.os }}/${{ matrix.arch }} Node ${{ matrix.node }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [16, 18, 20]
-    runs-on: ${{ matrix.os }}
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        node: [ 16, 18, 20 ]
+        arch: [ x64 ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+        # See https://github.com/nodejs/node-gyp/issues/2869
+      - name: Fix node-gyp and Python
+        run: python3 -m pip install packaging setuptools
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -25,10 +30,11 @@ jobs:
           run_install: |
             args: [--ignore-scripts]
 
-      - name: Use Node.js  ${{ matrix.node-version }}
+      - name: Use Node.js  ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
+          architecture: ${{ matrix.arch }}
           cache: "pnpm"
 
       - name: Build binary
@@ -39,5 +45,5 @@ jobs:
 
       - name: Release
         env:
-          NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.NODE_PRE_GYP_GITHUB_TOKEN }}
+          NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm binary:release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,22 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }} and Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }}/${{ matrix.arch }} Node ${{ matrix.node }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [16, 18, 20]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        node: [ 16, 18, 20 ]
+        arch: [ x64 ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+        # See https://github.com/nodejs/node-gyp/issues/2869
+      - name: Fix node-gyp and Python
+        run: python3 -m pip install packaging setuptools
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -28,10 +33,11 @@ jobs:
           run_install: |
             args: [--ignore-scripts]
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
+          architecture: ${{ matrix.arch }}
           cache: "pnpm"
 
       - name: Build binary


### PR DESCRIPTION
this pr fix invalid configuration of github ci test and release, including run runnings in correctly os and use github default secret token.

it should build pre-build binaries as expected and upload them to github node registry without specify token manually.
