### PR TITLE
build: update binary package path and name format

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "module_name": "nodejieba",
     "module_path": "./build/Release/",
     "host": "https://github.com/yanyiwu/nodejieba/releases/download/",
-    "remote_path": "v{version}",
-    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz"
+    "remote_path": "v{version}/{platform}-{libc}",
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}-{libc}.tar.gz"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Include libc in the remote path and package name to support different libc implementations