### PR TITLE
ci: use npx to run node-pre-gyp commands

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Package Binary
       run: |
         npm install -g @mapbox/node-pre-gyp
-        @mapbox/node-pre-gyp package
+        npx @mapbox/node-pre-gyp package
     - name: Get Node ABI
       id: node_abi
       run: |

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "scripts": {
     "test": "mocha --timeout 10s -R spec test/test.js && mocha --timeout 10s -R spec test/load_dict_test.js",
-    "install": "@mapbox/node-pre-gyp install --fallback-to-build",
-    "rebuild": "@mapbox/node-pre-gyp rebuild"
+    "install": "npx @mapbox/node-pre-gyp install --fallback-to-build",
+    "rebuild": "npx @mapbox/node-pre-gyp rebuild"
   },
   "binary": {
     "module_name": "nodejieba",


### PR DESCRIPTION
Update GitHub workflow and package.json scripts to use npx for executing node-pre-gyp commands to ensure proper package resolution