### PR TITLE
Test Node.js 25 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x, 25.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         os: [ubuntu-latest, ubuntu-22.04-arm, macos-latest, windows-latest]
 
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- add Node.js 25.x to the GitHub Actions test matrix
- update `actions/checkout` to v6
- keep existing Node.js versions in place so current compatibility coverage remains visible

## Context
- Node.js currently lists 24.x as LTS and 25.x as Current.

## Testing
- Not run locally; workflow-only change.