### PR TITLE
[codex] Drop EOL Node.js versions from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x, 24.x, 25.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         os: [ubuntu-latest, ubuntu-22.04-arm, macos-latest, windows-latest]
 


### PR DESCRIPTION
## Summary

- Remove Node.js 16.x and 18.x from the GitHub Actions test matrix.
- Keep coverage on Node.js 20.x, 22.x, 24.x, and 25.x.

## Rationale

Node.js 16 and 18 are already end-of-life. Node.js 20 is still in the matrix for now because it reaches EOL on 2026-04-30; it should be removed on the next compatibility pass after that date.

## Validation

- Workflow-only change; validation is the pull request test matrix.