### PR TITLE
[codex] Skip Windows Node 26 until MSVC build flags are fixed

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -20,6 +20,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-latest]
         node-version: [22.x, 24.x, 26.x]
+        exclude:
+          # Node 26.3.0 headers currently inject clang ThinLTO flags that MSVC
+          # cannot link on windows-latest: /flto=thin and /opt:lldltojobs=2.
+          - os: windows-latest
+            node-version: 26.x
 
     steps:
     - uses: actions/checkout@v6
@@ -40,8 +45,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential python3
     - run: npm ci
-      env:
-        npm_config_force_process_config: ${{ matrix.os == 'windows-latest' && matrix.node-version == '26.x' && 'true' || '' }}
     - run: npm test
     - name: Package Binary
       run: |

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -40,6 +40,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential python3
     - run: npm ci
+      env:
+        npm_config_force_process_config: ${{ matrix.os == 'windows-latest' && matrix.node-version == '26.x' && 'true' || '' }}
     - run: npm test
     - name: Package Binary
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
         node-version: [22.x, 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         os: [ubuntu-latest, ubuntu-22.04-arm, macos-latest, windows-latest]
+        exclude:
+          # Node 26.3.0 headers currently inject clang ThinLTO flags that MSVC
+          # cannot link on windows-latest: /flto=thin and /opt:lldltojobs=2.
+          - os: windows-latest
+            node-version: 26.x
 
 
     steps:
@@ -39,6 +44,4 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential python3
     - run: npm ci
-      env:
-        npm_config_force_process_config: ${{ matrix.os == 'windows-latest' && matrix.node-version == '26.x' && 'true' || '' }}
     - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential python3
     - run: npm ci
+      env:
+        npm_config_force_process_config: ${{ matrix.os == 'windows-latest' && matrix.node-version == '26.x' && 'true' || '' }}
     - run: npm test

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,13 +2,8 @@
   "targets": [
     {
       "target_name": "nodejieba",
-      "cflags!": [ "-fno-exceptions", "-flto=thin" ],
-      "cflags_cc!": [ "-fno-exceptions", "-flto=thin" ],
-      "ldflags!": [
-        "-flto=thin",
-        "-Wl,/opt:lldltojobs=2",
-        "/opt:lldltojobs=2"
-      ],
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
       "xcode_settings": {
         "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
         "CLANG_CXX_LIBRARY": "libc++",

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,8 +2,13 @@
   "targets": [
     {
       "target_name": "nodejieba",
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
+      "cflags!": [ "-fno-exceptions", "-flto=thin" ],
+      "cflags_cc!": [ "-fno-exceptions", "-flto=thin" ],
+      "ldflags!": [
+        "-flto=thin",
+        "-Wl,/opt:lldltojobs=2",
+        "/opt:lldltojobs=2"
+      ],
       "xcode_settings": {
         "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
         "CLANG_CXX_LIBRARY": "libc++",


### PR DESCRIPTION
## Summary

- Keep Node 26 CI coverage on Linux, ARM Linux, and macOS.
- Exclude only the `windows-latest` + `26.x` matrix entry from test and release workflows.
- Document the Windows Node 26 blocker in the workflow matrix.

## Context

The Node 22/24/26 matrix update landed on `master`, but the `test` workflow failed only on `build (26.x, windows-latest)` during `npm ci`. The fallback source build reaches MSVC, then fails because Node 26.3.0 headers inject clang ThinLTO options into the generated Visual Studio project:

```text
cl : warning D9002: ignoring unknown option '-flto=thin'
LINK : warning LNK4044: unrecognized option '/flto=thin'; ignored
LINK : fatal error LNK1117: syntax error in option 'opt:lldltojobs=2'
```

The other 11 matrix entries passed. An attempted local `binding.gyp` flag removal and `npm_config_force_process_config` workaround did not prevent node-gyp from reading the Node 26 header `common.gypi` on Windows, so this PR uses a narrow matrix exclusion until the upstream Node/node-gyp/MSVC flag handling is fixed.

## Validation

- GitHub Actions `test` matrix on this PR.