### PR TITLE
Update cppjieba after limonp removal

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,6 @@
       "include_dirs" : [
         "<!(node -p \"require('node-addon-api').include_dir\")",
         "./submodules/cppjieba/include",
-        "./submodules/cppjieba/deps/limonp/include",
       ],
       'configurations': {
         'Release': {


### PR DESCRIPTION
## Summary

- update the `cppjieba` submodule to `eed6bfe483105d1db4bfbebaf796f60c173d6e84`
- remove the obsolete `deps/limonp/include` path from `binding.gyp`

`cppjieba` now carries its required helpers in `include/cppjieba/Utils.hpp` and no longer has a `limonp` submodule.

## Validation

- `env npm_config_cache=/tmp/npm-cache-nodejieba-20260609 npm ci`
- `npm test` (27 tests passed)
- `npm audit` reported 0 vulnerabilities